### PR TITLE
fix(routes): redirect to `/404` instead of `/invalid`

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -24,11 +24,17 @@ export enum HEADERS {
 }
 
 export enum FILE {
+  // https://github.com/ai/nanoid#api
+  KEY_ALPHABET = 'A-Za-z0-9_-',
   KEY_LENGTH = 7,
   // https://stackoverflow.com/a/26119120
   PASSWORD_ALPHABET = '-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ?/@_~!$&*+=',
   PASSWORD_LENGTH = 9,
 }
+
+export const FILE_KEY_REGEX = new RegExp(
+  `^[${FILE.KEY_ALPHABET}]{${FILE.KEY_LENGTH}}$`
+);
 
 export const FILE_PASSWORD_REGEX = new RegExp(
   `^[${FILE.PASSWORD_ALPHABET}]{${FILE.PASSWORD_LENGTH}}$`

--- a/src/routes/loaders/fileKeyLoader.test.ts
+++ b/src/routes/loaders/fileKeyLoader.test.ts
@@ -1,0 +1,30 @@
+import { type LoaderFunctionArgs, redirect } from 'react-router-dom';
+
+import { fileKeyLoader } from './fileKeyLoader';
+
+jest.mock('react-router-dom', () => ({
+  redirect: jest.fn(),
+}));
+
+const mockedRedirect = jest.mocked(redirect);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it.each(['1234567', 'abcdefg', 'ABCDEFG', 'Abc456-', '0bc_789'])(
+  'does not redirect to /404 when params.fileKey is %p',
+  (fileKey) => {
+    fileKeyLoader({ params: { fileKey } } as unknown as LoaderFunctionArgs);
+    expect(mockedRedirect).not.toBeCalled();
+  }
+);
+
+it.each(['123456', '12345678', '123456#'])(
+  'redirects to /404 when params.fileKey is %p',
+  (fileKey) => {
+    fileKeyLoader({ params: { fileKey } } as unknown as LoaderFunctionArgs);
+    expect(mockedRedirect).toBeCalledTimes(1);
+    expect(mockedRedirect).toBeCalledWith('/404');
+  }
+);

--- a/src/routes/loaders/fileKeyLoader.ts
+++ b/src/routes/loaders/fileKeyLoader.ts
@@ -1,0 +1,9 @@
+import { type LoaderFunction, redirect } from 'react-router-dom';
+import { FILE_KEY_REGEX } from 'shared/constants';
+
+export const fileKeyLoader: LoaderFunction = ({ params }) => {
+  if (!FILE_KEY_REGEX.test(params.fileKey!)) {
+    return redirect('/404');
+  }
+  return null;
+};

--- a/src/routes/loaders/index.ts
+++ b/src/routes/loaders/index.ts
@@ -1,0 +1,1 @@
+export * from './fileKeyLoader';

--- a/src/routes/routes.test.tsx
+++ b/src/routes/routes.test.tsx
@@ -26,7 +26,12 @@ it('matches snapshot', () => {
           path="/share"
         />
         <Route
+          element={<NotFoundLoader />}
+          path="/404"
+        />
+        <Route
           element={<ConfirmDownloadLoader />}
+          loader={[Function]}
           path="/:fileKey"
         />
         <Route

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -8,6 +8,8 @@ import NotFound from 'src/pages/NotFound';
 import ShareLink from 'src/pages/ShareLink';
 import UploadFile from 'src/pages/UploadFile';
 
+import { fileKeyLoader } from './loaders';
+
 const routes = (
   <Route path="/" element={<Layout />}>
     <Route errorElement={<ErrorBoundary />}>
@@ -15,7 +17,12 @@ const routes = (
       <Route path="/download" element={<DownloadFile />} />
       <Route path="/invalid" element={<InvalidLink />} />
       <Route path="/share" element={<ShareLink />} />
-      <Route path="/:fileKey" element={<ConfirmDownload />} />
+      <Route path="/404" element={<NotFound />} />
+      <Route
+        path="/:fileKey"
+        element={<ConfirmDownload />}
+        loader={fileKeyLoader}
+      />
       <Route path="*" element={<NotFound />} />
     </Route>
   </Route>


### PR DESCRIPTION
Fix Cypress tests since `ConfirmDownload` will always redirect to `/invalid` instead of `/404`. As a result, check the route params first in the loader before rendering `ConfirmDownload`.