### PR TITLE
fix: set default config `API_URL` and update response init

### DIFF
--- a/functions/utils.ts
+++ b/functions/utils.ts
@@ -38,7 +38,9 @@ export function getCustomMetadata(obj: R2ObjectBody) {
  * @returns - Response init.
  */
 export function getResponseInit(environment: Env['NODE_ENV']) {
-  const responseInit: ResponseInit = {};
+  const responseInit: ResponseInit = {
+    headers: {},
+  };
   if (environment === 'development') {
     responseInit.headers = {
       'Access-Control-Allow-Origin': '*',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
-export const API_URL = import.meta.env.VITE_API_URL;
+export const API_URL = import.meta.env.VITE_API_URL || '';
 export const APP_NAME = import.meta.env.VITE_APP_NAME;
 export const APP_VERSION = import.meta.env.VITE_APP_VERSION;
 export const DEV = import.meta.env.DEV;


### PR DESCRIPTION
Default config `API_URL` to `''` or else it will include `undefined` in the request path:

```
Failed to load resource: the server responded with a status of 405
/undefined/api/files
```

Add property headers to utils `getResponseInit` or else it will throw an exception:

```
TypeError: Cannot set properties of undefined (setting 'Access-Control-Expose-Headers')
```