### PR TITLE
fix(pages): update copy for file not found in DownloadFileError

### DIFF
--- a/src/pages/DownloadFile/DownloadFileError.test.tsx
+++ b/src/pages/DownloadFile/DownloadFileError.test.tsx
@@ -20,14 +20,27 @@ it('renders heading', () => {
   ).toBeInTheDocument();
 });
 
-it('renders paragraph', () => {
-  renderWithProviders(<DownloadFileError />);
-  expect(
-    screen.getByText('File failed to download. Please try again.')
-  ).toBeInTheDocument();
+describe('status 403', () => {
+  it('navigates to /invalid', () => {
+    renderWithProviders(<DownloadFileError status={403} />);
+    expect(mockNavigate).toBeCalledWith('/invalid', { replace: true });
+  });
 });
 
-it('navigates to /invalid when status is 403', () => {
-  renderWithProviders(<DownloadFileError status={403} />);
-  expect(mockNavigate).toBeCalledWith('/invalid', { replace: true });
+describe('status 404', () => {
+  it('renders paragraph', () => {
+    renderWithProviders(<DownloadFileError status={404} />);
+    expect(
+      screen.getByText('File has been deleted or does not exist.')
+    ).toBeInTheDocument();
+  });
+});
+
+describe.each([undefined, 400, 500])('status %p', (status) => {
+  it('renders paragraph', () => {
+    renderWithProviders(<DownloadFileError status={status} />);
+    expect(
+      screen.getByText('File failed to download. Please try again.')
+    ).toBeInTheDocument();
+  });
 });

--- a/src/pages/DownloadFile/DownloadFileError.tsx
+++ b/src/pages/DownloadFile/DownloadFileError.tsx
@@ -22,7 +22,9 @@ export default function DownloadFileError(props: Props) {
       </Typography>
 
       <Typography paragraph>
-        File failed to download. Please try again.
+        {props.status === 404
+          ? 'File has been deleted or does not exist.'
+          : 'File failed to download. Please try again.'}
       </Typography>
     </>
   );


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(pages): update copy for file not found in DownloadFileError

## What is the current behavior?

When file is deleted or not found, the copy tells the user to try again

## What is the new behavior?

When file is deleted or not found, the copy tells the user that the file has been deleted or does not exist

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests