### PR TITLE
fix(pages): navigate to home when delete status is 404 in ShareLink

### DIFF
--- a/src/pages/ShareLink/ShareLink.test.tsx
+++ b/src/pages/ShareLink/ShareLink.test.tsx
@@ -133,21 +133,25 @@ describe('with file key and password', () => {
     expect(mockDeleteFile).not.toBeCalled();
   });
 
-  it('deletes file', async () => {
-    mockDeleteFile.mockReturnValue({ unwrap: jest.fn() });
-    renderWithProviders(<ShareLink />);
-    await waitFor(() => {
-      fireEvent.click(screen.getByRole('button', { name: 'Delete file' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
-    });
-    expect(mockDeleteFile).toBeCalledTimes(1);
-    expect(mockDeleteFile).toBeCalledWith(key);
-    expect(store.getState().file).toMatchInlineSnapshot(`
+  describe.each([200, 404])('when delete status is %d', (status) => {
+    it('closes modal and resets store', async () => {
+      const unwrap = jest.fn().mockRejectedValueOnce({ status });
+      mockDeleteFile.mockReturnValue({ unwrap });
+      renderWithProviders(<ShareLink />);
+      await waitFor(() => {
+        fireEvent.click(screen.getByRole('button', { name: 'Delete file' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      });
+      expect(mockDeleteFile).toBeCalledTimes(1);
+      expect(mockDeleteFile).toBeCalledWith(key);
+      expect(unwrap).toBeCalledTimes(1);
+      expect(store.getState().file).toMatchInlineSnapshot(`
       {
         "files": [],
         "key": "",
         "password": "",
       }
     `);
+    });
   });
 });

--- a/src/pages/ShareLink/ShareLink.tsx
+++ b/src/pages/ShareLink/ShareLink.tsx
@@ -32,9 +32,18 @@ export default function ShareLink() {
   const openDialog = useCallback(() => setIsDialogOpen(true), []);
   const closeDialog = useCallback(() => setIsDialogOpen(false), []);
   const handleDeleteFile = useCallback(async () => {
-    await deleteFile(file.key!).unwrap();
-    setIsDialogOpen(false);
-    dispatch(actions.resetFile());
+    let status = 200;
+
+    try {
+      await deleteFile(file.key!).unwrap();
+    } catch (error: unknown) {
+      status = (error as { status: number }).status;
+    }
+
+    if (status === 200 || status === 404) {
+      setIsDialogOpen(false);
+      dispatch(actions.resetFile());
+    }
   }, [file.key]);
 
   if (!file.key) {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(pages): navigate to home when delete status is 404 in ShareLink

## What is the current behavior?

When delete response status is 404, the delete modal does not go away

## What is the new behavior?

When delete response status is 404, delete modal goes away and user navigates to home

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests