### PR TITLE
fix(pages): disable the button when uploading in UploadFile

### DIFF
--- a/src/pages/UploadFile/UploadFile.test.tsx
+++ b/src/pages/UploadFile/UploadFile.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { useSelector } from 'src/hooks';
+import { useSelector, useUploadFileMutation } from 'src/hooks';
 import type { RootState } from 'src/types';
 import { createZipFile } from 'src/utils';
 import { renderWithProviders, store } from 'test/helpers';
@@ -21,10 +21,11 @@ const mockUploadFile = jest.fn();
 jest.mock('src/hooks', () => ({
   ...jest.requireActual('src/hooks'),
   useSelector: jest.fn(),
-  useUploadFileMutation: jest.fn(() => [mockUploadFile]),
+  useUploadFileMutation: jest.fn(() => [mockUploadFile, {}]),
 }));
 
 const mockedUseSelector = jest.mocked(useSelector);
+const mockedUseUploadFileMutation = jest.mocked(useUploadFileMutation);
 
 jest.mock('src/utils', () => ({
   ...jest.requireActual('src/utils'),
@@ -52,6 +53,16 @@ it('renders Dropzone', () => {
 it('renders upload button', () => {
   renderWithProviders(<UploadFile />);
   expect(screen.getByRole('button', { name: 'Upload' })).toBeInTheDocument();
+});
+
+it('disables the upload button when loading', () => {
+  mockedUseUploadFileMutation.mockReturnValueOnce([
+    mockUploadFile,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { isLoading: true } as any,
+  ]);
+  renderWithProviders(<UploadFile />);
+  expect(screen.getByRole('button', { name: 'Upload' })).toBeDisabled();
 });
 
 describe('without files', () => {

--- a/src/pages/UploadFile/UploadFile.tsx
+++ b/src/pages/UploadFile/UploadFile.tsx
@@ -13,7 +13,7 @@ export default function UploadFile() {
   const dispatch = useDispatch();
   const files = useSelector((state) => state.file.files) || [];
   const navigate = useNavigate();
-  const [uploadFile] = useUploadFileMutation();
+  const [uploadFile, uploadFileResult] = useUploadFileMutation();
 
   const handleClick = useCallback(async () => {
     /* istanbul ignore next */
@@ -53,7 +53,7 @@ export default function UploadFile() {
       <Previews />
 
       <Button
-        disabled={!files.length}
+        disabled={!files.length || uploadFileResult.isLoading}
         onClick={handleClick}
         sx={{ marginTop: 2 }}
         variant="contained"


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(pages): disable the button when uploading in UploadFile

## What is the current behavior?

Upload button is not disabled when uploading file

## What is the new behavior?

Upload button is disabled when uploading file

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests