### PR TITLE
fix(components): make acceptStyle color the same as focusStyle in Dropzone

### DIFF
--- a/src/components/Dropzone/hooks/__snapshots__/useStyle.test.ts.snap
+++ b/src/components/Dropzone/hooks/__snapshots__/useStyle.test.ts.snap
@@ -40,7 +40,7 @@ exports[`renders style when isFocused=false, isDragAccept=true, isDragReject=fal
 {
   "alignItems": "center",
   "backgroundColor": "#fafafa",
-  "borderColor": "#212121",
+  "borderColor": "#b71c1c",
   "borderRadius": 2,
   "borderStyle": "dashed",
   "borderWidth": 2,

--- a/src/components/Dropzone/styles.ts
+++ b/src/components/Dropzone/styles.ts
@@ -24,7 +24,7 @@ export const focusedStyle = {
 } as const;
 
 export const acceptStyle = {
-  borderColor: grey[900],
+  borderColor: red[900],
 } as const;
 
 export const rejectStyle = {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(components): make acceptStyle color the same as focusStyle in Dropzone

## What is the current behavior?

acceptStyle color is gray

## What is the new behavior?

acceptStyle color is red

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests