### PR TITLE
fix(Dropzone): don't allow more than 1 file to be added to useOnDrop

### DIFF
--- a/src/components/Dropzone/hooks/useOnDrop.ts
+++ b/src/components/Dropzone/hooks/useOnDrop.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import type { DropEvent, DropzoneOptions, FileRejection } from 'react-dropzone';
-import { useDispatch } from 'src/hooks';
+import { MAX_FILES } from 'shared/constants';
+import { useDispatch, useSelector } from 'src/hooks';
 import { actions } from 'src/store';
 import { blobToBase64 } from 'src/utils';
 
@@ -8,6 +9,7 @@ type OnDrop = Required<DropzoneOptions>['onDrop'];
 
 export function useOnDrop() {
   const dispatch = useDispatch();
+  const filesCount = useSelector((state) => state.file.files.length);
 
   const onDrop: OnDrop = useCallback(
     async (
@@ -17,7 +19,11 @@ export function useOnDrop() {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       event: DropEvent
     ) => {
-      if (fileRejections.length || !acceptedFiles.length) {
+      if (
+        fileRejections.length ||
+        !acceptedFiles.length ||
+        filesCount >= MAX_FILES.DEFAULT
+      ) {
         return;
       }
 
@@ -34,7 +40,7 @@ export function useOnDrop() {
 
       dispatch(actions.addFiles(files));
     },
-    []
+    [filesCount]
   );
 
   return onDrop;


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(Dropzone): don't allow more than 1 file to be added to useOnDrop

## What is the current behavior?

Multiple files can be added to Dropzone

## What is the new behavior?

Only 1 file can be added to Dropzone

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation