### PR TITLE
fix(pages): capitalize `APP_NAME` and set document title in home

### DIFF
--- a/cypress/e2e/404/404.feature
+++ b/cypress/e2e/404/404.feature
@@ -6,3 +6,4 @@ Feature: 404
       And I see text "Go home"
     When I click on link "home"
     Then I see URL "/"
+      And I see document title "Encrypit"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,6 @@
+import { capitalize } from 'src/utils';
+
 export const API_URL = import.meta.env.VITE_API_URL || '';
-export const APP_NAME = import.meta.env.VITE_APP_NAME || 'encrypit';
+export const APP_NAME = capitalize(import.meta.env.VITE_APP_NAME) || 'Encrypit';
 export const APP_VERSION = import.meta.env.VITE_APP_VERSION;
 export const DEV = import.meta.env.DEV;

--- a/src/pages/NotFound/NotFound.tsx
+++ b/src/pages/NotFound/NotFound.tsx
@@ -8,7 +8,7 @@ export default function NotFound() {
 
   return (
     <>
-      <Typography component="h1" paragraph variant="h4">
+      <Typography component="h1" gutterBottom variant="h4">
         Not Found
       </Typography>
 

--- a/src/pages/UploadFile/UploadFile.tsx
+++ b/src/pages/UploadFile/UploadFile.tsx
@@ -6,11 +6,18 @@ import { useNavigate } from 'react-router-dom';
 import { generateFilePassword } from 'shared/id';
 import Dropzone from 'src/components/Dropzone';
 import Previews from 'src/components/Previews';
-import { useDispatch, useSelector, useUploadFileMutation } from 'src/hooks';
+import { APP_NAME } from 'src/config';
+import {
+  useDispatch,
+  useSelector,
+  useSetDocumentTitle,
+  useUploadFileMutation,
+} from 'src/hooks';
 import { actions } from 'src/store';
 import { createFormData, createZipFile } from 'src/utils';
 
 export default function UploadFile() {
+  useSetDocumentTitle(APP_NAME);
   const dispatch = useDispatch();
   const files = useSelector((state) => state.file.files) || [];
   const navigate = useNavigate();

--- a/src/utils/capitalize.test.ts
+++ b/src/utils/capitalize.test.ts
@@ -1,0 +1,12 @@
+import { capitalize } from './capitalize';
+
+describe('capitalize', () => {
+  it.each([
+    ['', ''],
+    ['a', 'A'],
+    ['hello world', 'Hello world'],
+    ['1', '1'],
+  ])('capitalizes %p', (input, output) => {
+    expect(capitalize(input)).toBe(output);
+  });
+});

--- a/src/utils/capitalize.ts
+++ b/src/utils/capitalize.ts
@@ -1,0 +1,6 @@
+export function capitalize(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return text[0].toUpperCase() + text.slice(1);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './capitalize';
 export * from './filename';
 export * from './form';
 export * from './hash';


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(pages): capitalize APP_NAME and set document title in home

## What is the current behavior?

When you go to `/404` and then go to home, the document title says `Not Found`

## What is the new behavior?

Going to `/404` and then back to home, the document title will update correctly

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation