### PR TITLE
fix(components): set Header and Layout Container max-width to md

### DIFF
--- a/src/components/Container/Container.test.tsx
+++ b/src/components/Container/Container.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+
+import Container from './Container';
+
+it('renders children', () => {
+  const props = { children: 'children' };
+  render(<Container {...props} />);
+  expect(screen.getByText(props.children)).toBeInTheDocument();
+});
+
+it('sets component tag', () => {
+  const props = {
+    children: 'children',
+    component: 'main',
+  };
+  render(<Container {...props} />);
+  const element = screen.getByText(props.children);
+  expect(element.tagName).toBe(props.component.toUpperCase());
+});

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,0 +1,11 @@
+import MaterialContainer, {
+  type ContainerProps,
+} from '@mui/material/Container';
+
+interface Props extends ContainerProps {
+  component?: string;
+}
+
+export default function Container(props: Props) {
+  return <MaterialContainer maxWidth="md" {...props} />;
+}

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Container';

--- a/src/components/Dropzone/hooks/__snapshots__/useStyle.test.ts.snap
+++ b/src/components/Dropzone/hooks/__snapshots__/useStyle.test.ts.snap
@@ -13,7 +13,7 @@ exports[`renders style when isFocused=false, isDragAccept=false, isDragReject=fa
   "flex": 1,
   "flexDirection": "column",
   "outline": "none",
-  "padding": "5rem 1rem",
+  "padding": "6rem 1rem",
   "transition": "border .24s ease-in-out",
 }
 `;
@@ -31,7 +31,7 @@ exports[`renders style when isFocused=false, isDragAccept=false, isDragReject=tr
   "flex": 1,
   "flexDirection": "column",
   "outline": "none",
-  "padding": "5rem 1rem",
+  "padding": "6rem 1rem",
   "transition": "border .24s ease-in-out",
 }
 `;
@@ -49,7 +49,7 @@ exports[`renders style when isFocused=false, isDragAccept=true, isDragReject=fal
   "flex": 1,
   "flexDirection": "column",
   "outline": "none",
-  "padding": "5rem 1rem",
+  "padding": "6rem 1rem",
   "transition": "border .24s ease-in-out",
 }
 `;
@@ -67,7 +67,7 @@ exports[`renders style when isFocused=true, isDragAccept=false, isDragReject=fal
   "flex": 1,
   "flexDirection": "column",
   "outline": "none",
-  "padding": "5rem 1rem",
+  "padding": "6rem 1rem",
   "transition": "border .24s ease-in-out",
 }
 `;

--- a/src/components/Dropzone/hooks/useStyle.test.ts
+++ b/src/components/Dropzone/hooks/useStyle.test.ts
@@ -17,7 +17,7 @@ it('renders base style by default', () => {
       "flex": 1,
       "flexDirection": "column",
       "outline": "none",
-      "padding": "5rem 1rem",
+      "padding": "6rem 1rem",
       "transition": "border .24s ease-in-out",
     }
   `);

--- a/src/components/Dropzone/styles.ts
+++ b/src/components/Dropzone/styles.ts
@@ -15,7 +15,7 @@ export const baseStyle = {
   flex: 1,
   flexDirection: 'column',
   outline: 'none',
-  padding: '5rem 1rem',
+  padding: '6rem 1rem',
   transition: 'border .24s ease-in-out',
 } as const;
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,11 +3,11 @@ import HelpIcon from '@mui/icons-material/Help';
 import SecurityIcon from '@mui/icons-material/Security';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
 import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
 import Toolbar from '@mui/material/Toolbar';
 import { Link as RouterLink } from 'react-router-dom';
+import Container from 'src/components/Container';
 
 export default function Header() {
   return (

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
-import Container from '@mui/material/Container';
 import { Outlet } from 'react-router-dom';
+import Container from 'src/components/Container';
 
 import Header from '../Header';
 

--- a/src/pages/Support/Support.tsx
+++ b/src/pages/Support/Support.tsx
@@ -1,8 +1,7 @@
 import support from 'docs/support.md?raw';
 import Markdown from 'src/components/Markdown';
 import { APP_NAME } from 'src/config';
-
-import { useSetDocumentTitle } from '../../hooks';
+import { useSetDocumentTitle } from 'src/hooks';
 
 export default function Support() {
   useSetDocumentTitle(`${APP_NAME} Support`);


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(components): set Header and Layout Container max-width to md (900px)

https://mui.com/material-ui/customization/breakpoints/

## What is the current behavior?

Container max-width used to be lg (1200px)

## What is the new behavior?

Container max-width is now md (900px)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation