### PR TITLE
fix(functions): respond with 413 Payload Too Large if file is larger than 5 MB

### DIFF
--- a/functions/api/files/index.ts
+++ b/functions/api/files/index.ts
@@ -1,7 +1,7 @@
-import { LENGTH_REQUIRED } from 'costatus';
+import { LENGTH_REQUIRED, PAYLOAD_TOO_LARGE } from 'costatus';
 import type { Env } from 'functions/types';
 import { getBucket, getResponseInit } from 'functions/utils';
-import { FORM_DATA } from 'shared/constants';
+import { FORM_DATA, MAX_SIZE } from 'shared/constants';
 import { generateFileKey } from 'shared/id';
 import type { CustomMetadata } from 'shared/types';
 
@@ -20,6 +20,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
   if (!file.size) {
     init.status = LENGTH_REQUIRED;
+    return new Response(body, init);
+  }
+
+  if (file.size > MAX_SIZE.DEFAULT) {
+    init.status = PAYLOAD_TOO_LARGE;
     return new Response(body, init);
   }
 


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(functions): check file max size & return with 413 Payload Too Large

## What is the current behavior?

No error when uploaded file is larger than 5 MB in API

## What is the new behavior?

API checks that uploaded file is not larger than 5 MB and if it is, responds with 413 Payload Too Large

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation