### PR TITLE
refactor(constants): remove deprecated file key and password length

### DIFF
--- a/cypress/e2e/invalid/invalid.feature
+++ b/cypress/e2e/invalid/invalid.feature
@@ -1,6 +1,18 @@
 Feature: Invalid
+  Scenario: I have invalid file key length
+    Given I visit "/12345678"
+    Then I see URL "/404"
+    When I visit "/1234567890"
+    Then I see URL "/404"
+
+  Scenario: I have invalid file password length
+    Given I visit "/123456789#12345678901"
+    Then I see URL "/invalid"
+    When I visit "/123456789#1234567890123"
+    Then I see URL "/invalid"
+
   Scenario: I get message that file link is missing hash
-    Given I visit "/1234567"
+    Given I visit "/123456789"
     Then I see URL "/invalid"
       And I see heading "File link invalid"
       And I see text "The link is incomplete or incorrect. Please make sure all the characters after the # are included."
@@ -8,10 +20,10 @@ Feature: Invalid
     Then I do not see URL "/"
 
   Scenario: I cannot download an invalid file link
-    Given I visit "/1234567#123456789"
-    Then I see URL "/1234567"
+    Given I visit "/123456789#123456789012"
+    Then I see URL "/123456789"
       And I see heading "Download and delete?"
-      And I see text "You're about to download and delete the file with key 1234567"
+      And I see text "You're about to download and delete the file with key 123456789"
     When I click on link "Yes, download the file"
     Then I see URL "/download"
       And I see heading "Download error"

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -33,13 +33,11 @@ export enum FILE {
 }
 
 export const FILE_KEY_REGEX = new RegExp(
-  // TODO: remove `7,`
-  `^[${FILE.KEY_ALPHABET}]{7,${FILE.KEY_LENGTH}}$`,
+  `^[${FILE.KEY_ALPHABET}]{${FILE.KEY_LENGTH}}$`,
 );
 
 export const FILE_PASSWORD_REGEX = new RegExp(
-  // TODO: remove `9,`
-  `^[${FILE.PASSWORD_ALPHABET}]{9,${FILE.PASSWORD_LENGTH}}$`,
+  `^[${FILE.PASSWORD_ALPHABET}]{${FILE.PASSWORD_LENGTH}}$`,
 );
 
 /**

--- a/src/pages/ConfirmDownload/ConfirmDownload.test.tsx
+++ b/src/pages/ConfirmDownload/ConfirmDownload.test.tsx
@@ -79,8 +79,8 @@ describe('when params has fileKey but location hash does not have password', () 
 });
 
 describe('when params has fileKey and locaton hash has password', () => {
-  const password = 'password9';
-  const params = { fileKey: 'fileKey' };
+  const password = 'password_012';
+  const params = { fileKey: 'fileKey_9' };
   const location = { hash: `#${password}`, pathname: params.fileKey };
 
   beforeEach(() => {

--- a/src/routes/loaders/fileKeyLoader.test.ts
+++ b/src/routes/loaders/fileKeyLoader.test.ts
@@ -1,4 +1,5 @@
 import { type LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { FILE } from 'shared/constants';
 
 import { fileKeyLoader } from './fileKeyLoader';
 
@@ -20,7 +21,9 @@ it.each(['123456789', 'abcdefghi', 'ABCDEFGHI', 'Abc456-89', '0bc_56789'])(
   },
 );
 
-it.each(['123456', '1234567890', '123456#'])(
+const random = (length: number) => String(Date.now()).slice(0, length);
+
+it.each([random(FILE.KEY_LENGTH - 1), random(FILE.KEY_LENGTH + 1), '1234567#'])(
   'redirects to /404 when params.fileKey is %p',
   (fileKey) => {
     fileKeyLoader({ params: { fileKey } } as unknown as LoaderFunctionArgs);


### PR DESCRIPTION
## What is the motivation for this pull request?

refactor(constants): remove deprecated file key and password length

Release-As: 1.5.1

## What is the current behavior?

- File key regex checks for 7-9 length
- File password regex checks for 9-12 length

## What is the new behavior?

- File key regex checks for 9 length
- File password regex checks for 12 length

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation