### PR TITLE
feat(api): check password hash before deleting file

### DIFF
--- a/src/pages/DownloadFile/DownloadFile.test.tsx
+++ b/src/pages/DownloadFile/DownloadFile.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { useLazyDownloadFileQuery, useSelector } from 'src/hooks';
 import type { RootState } from 'src/types';
 import { unzip } from 'src/utils';
@@ -12,10 +12,7 @@ jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(() => mockNavigate),
 }));
 
-const mockDeleteFile = jest.fn();
-
 jest.mock('src/hooks', () => ({
-  useDeleteFileMutation: jest.fn(() => [mockDeleteFile]),
   useLazyDownloadFileQuery: jest.fn(),
   useSelector: jest.fn(),
 }));
@@ -280,14 +277,5 @@ describe('isSuccess', () => {
           'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86',
       });
     });
-  });
-
-  it('deletes file on download', async () => {
-    renderWithProviders(<DownloadFile />);
-    await waitFor(() => {
-      fireEvent.click(screen.getByRole('link', { name: 'Download file' }));
-    });
-    expect(mockDeleteFile).toHaveBeenCalledTimes(1);
-    expect(mockDeleteFile).toHaveBeenCalledWith(file.key);
   });
 });

--- a/src/pages/DownloadFile/DownloadFile.tsx
+++ b/src/pages/DownloadFile/DownloadFile.tsx
@@ -8,11 +8,7 @@ import { base64ToBlob, blobToBase64 } from 'file64';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Link as RouterLink } from 'react-router-dom';
-import {
-  useDeleteFileMutation,
-  useLazyDownloadFileQuery,
-  useSelector,
-} from 'src/hooks';
+import { useLazyDownloadFileQuery, useSelector } from 'src/hooks';
 import { generateFileName, hashPassword, unzip } from 'src/utils';
 
 import DownloadFileError from './DownloadFileError';
@@ -22,7 +18,6 @@ export default function DownloadFile() {
   const navigate = useNavigate();
   const [downloadUrl, setDownloadUrl] = useState('');
   const [downloadFile, downloadFileResult] = useLazyDownloadFileQuery();
-  const [deleteFile] = useDeleteFileMutation();
   const linkRef = useRef<HTMLAnchorElement>(null);
 
   useEffect(() => {
@@ -52,7 +47,6 @@ export default function DownloadFile() {
     if (downloadUrl && file.key) {
       /* istanbul ignore next */
       linkRef.current?.click();
-      deleteFile(file.key);
     }
   }, [downloadUrl, file.key]);
 

--- a/src/store/api/fileApi.test.ts
+++ b/src/store/api/fileApi.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { createFormData } from 'src/utils';
+import { createFormData, hashPassword } from 'src/utils';
 import { fetchMock, mockFiles, wrapper } from 'test/helpers';
 
 import { fileApi } from './fileApi';
@@ -12,53 +12,60 @@ beforeEach(() => {
 });
 
 describe('deleteFile', () => {
-  it('deletes file given key', async () => {
+  it('deletes file given key and password hash', async () => {
     const { result } = renderHook(() => fileApi.useDeleteFileMutation(), {
       wrapper,
     });
 
-    await act(() => {
+    await act(async () => {
       const [deleteFile] = result.current;
-      deleteFile(key);
+      deleteFile({
+        key,
+        passwordSHA512: await hashPassword(passwordSHA512),
+      });
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toMatchInlineSnapshot(`
-      Request {
-        "agent": undefined,
-        "compress": true,
-        "counter": 0,
-        "follow": 20,
-        "size": 0,
-        "timeout": 0,
-        Symbol(Body internals): {
-          "body": null,
-          "disturbed": false,
-          "error": null,
-        },
-        Symbol(Request internals): {
-          "headers": Headers {
-            Symbol(map): {},
-          },
-          "method": "DELETE",
-          "parsedURL": Url {
-            "auth": null,
-            "hash": null,
-            "host": "localhost",
-            "hostname": "localhost",
-            "href": "http://localhost/api/files/fileKey",
-            "path": "/api/files/fileKey",
-            "pathname": "/api/files/fileKey",
-            "port": null,
-            "protocol": "http:",
-            "query": null,
-            "search": null,
-            "slashes": true,
-          },
-          "redirect": "follow",
-          "signal": AbortSignal {},
-        },
-      }
+     Request {
+       "agent": undefined,
+       "compress": true,
+       "counter": 0,
+       "follow": 20,
+       "size": 0,
+       "timeout": 0,
+       Symbol(Body internals): {
+         "body": null,
+         "disturbed": false,
+         "error": null,
+       },
+       Symbol(Request internals): {
+         "headers": Headers {
+           Symbol(map): {
+             "X-Password-Sha512": [
+               "cc7222b9eb5b430fc446942a1a7b85f9593328f9c42f3a343a9c698e5574fdc3d9b435f94dbc667f82786b1747bbb27abe76bfddc473fbc2145b8d2e3265114e",
+             ],
+           },
+         },
+         "method": "DELETE",
+         "parsedURL": Url {
+           "auth": null,
+           "hash": null,
+           "host": "localhost",
+           "hostname": "localhost",
+           "href": "http://localhost/api/files/fileKey",
+           "path": "/api/files/fileKey",
+           "pathname": "/api/files/fileKey",
+           "port": null,
+           "protocol": "http:",
+           "query": null,
+           "search": null,
+           "slashes": true,
+         },
+         "redirect": "follow",
+         "signal": AbortSignal {},
+       },
+     }
     `);
   });
 });

--- a/src/store/api/fileApi.ts
+++ b/src/store/api/fileApi.ts
@@ -15,9 +15,12 @@ export const fileApi = createApi({
     /**
      * DELETE /api/files/[key]
      */
-    deleteFile: build.mutation<void, string>({
-      query: (fileKey: string) => ({
-        url: `/${fileKey}`,
+    deleteFile: build.mutation<void, { key: string; passwordSHA512: string }>({
+      query: ({ key, passwordSHA512 }) => ({
+        url: `/${key}`,
+        headers: {
+          [HEADERS.PASSWORD_SHA512]: passwordSHA512,
+        },
         method: 'DELETE',
       }),
     }),


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(api): check password hash before deleting file

## What is the current behavior?

Delete file endpoint only needs valid file key

## What is the new behavior?

Delete file endpoint requires both valid file key and password hash

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation