### PR TITLE
feat(pages): render "Upload file" link in DownloadFileError

### DIFF
--- a/cypress/e2e/invalid/invalid.feature
+++ b/cypress/e2e/invalid/invalid.feature
@@ -28,5 +28,6 @@ Feature: Invalid
     Then I see URL "/download"
       And I see heading "Download error"
       And I see text "File has been deleted or does not exist."
+      And I see link "Upload file"
     When I go back
     Then I do not see URL "/"

--- a/src/pages/DownloadFile/DownloadFileError.test.tsx
+++ b/src/pages/DownloadFile/DownloadFileError.test.tsx
@@ -28,11 +28,18 @@ describe('status 403', () => {
 });
 
 describe('status 404', () => {
-  it('renders paragraph', () => {
+  beforeEach(() => {
     renderWithProviders(<DownloadFileError status={404} />);
+  });
+
+  it('renders description', () => {
     expect(
       screen.getByText('File has been deleted or does not exist.'),
     ).toBeInTheDocument();
+  });
+
+  it('renders home link', () => {
+    expect(screen.getByText('Upload file')).toHaveAttribute('to', '/');
   });
 });
 

--- a/src/pages/DownloadFile/DownloadFileError.tsx
+++ b/src/pages/DownloadFile/DownloadFileError.tsx
@@ -1,6 +1,7 @@
+import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 interface Props {
   status?: number;
@@ -26,6 +27,10 @@ export default function DownloadFileError(props: Props) {
           ? 'File has been deleted or does not exist.'
           : 'File failed to download. Please try again.'}
       </Typography>
+
+      <Button component={Link} replace to="/" variant="outlined">
+        Upload file
+      </Button>
     </>
   );
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(pages): render "Upload file" link in DownloadFileError

## What is the current behavior?

No "Upload file" link in DownloadFileError

## What is the new behavior?

"Upload file" link in DownloadFileError

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation