### PR TITLE
feat(ShareLink): display snackbar message when "Copy link" is pressed

### DIFF
--- a/cypress/e2e/upload/upload.feature
+++ b/cypress/e2e/upload/upload.feature
@@ -12,6 +12,8 @@ Feature: Upload
       And I see link "http://localhost:5173/"
       And I see button "Copy link"
       And I see link "Email link"
+    When I click on button "Copy link"
+    Then I see text "Copied link"
     When I click on button "Delete file"
     Then I see heading "Are you sure you want to delete this file?"
       And I see text "This action cannot be undone."

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -46,3 +46,5 @@ export const FILE_PASSWORD_REGEX = new RegExp(
 export enum MIME {
   ZIP = 'application/zip',
 }
+
+export const ONE_SECOND = 1000;

--- a/src/components/Dropzone/hooks/useOnDropRejected.ts
+++ b/src/components/Dropzone/hooks/useOnDropRejected.ts
@@ -17,7 +17,6 @@ export function useOnDropRejected() {
         message: fileRejections[0].errors[0].message,
         open: true,
       });
-      return;
     },
     [snackbar],
   );

--- a/src/pages/ShareLink/ShareLink.test.tsx
+++ b/src/pages/ShareLink/ShareLink.test.tsx
@@ -106,6 +106,11 @@ describe('with file key and password', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText).toHaveBeenCalledWith(link);
+    expect(store.getState().snackbar).toMatchObject({
+      autoHideDuration: 2000,
+      message: 'Copied link',
+      open: true,
+    });
   });
 
   it('emails link', () => {

--- a/src/pages/ShareLink/ShareLink.tsx
+++ b/src/pages/ShareLink/ShareLink.tsx
@@ -7,8 +7,14 @@ import { NOT_FOUND, OK } from 'costatus';
 import { useCallback, useEffect, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
+import { ONE_SECOND } from 'shared/constants';
 import DeleteDialog from 'src/components/DeleteDialog';
-import { useDeleteFileMutation, useDispatch, useSelector } from 'src/hooks';
+import {
+  useDeleteFileMutation,
+  useDispatch,
+  useSelector,
+  useSnackbar,
+} from 'src/hooks';
 import { actions } from 'src/store';
 import { hashPassword } from 'src/utils';
 
@@ -16,7 +22,7 @@ export default function ShareLink() {
   const dispatch = useDispatch();
   const file = useSelector((state) => state.file);
   const navigate = useNavigate();
-  const link = `${location.origin}/${file.key}#${file.password}`;
+  const snackbar = useSnackbar();
   const [deleteFile] = useDeleteFileMutation();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -26,10 +32,15 @@ export default function ShareLink() {
     }
   }, [file.key]);
 
-  const copyLink = useCallback(
-    () => navigator.clipboard.writeText(link),
-    [link],
-  );
+  const link = `${location.origin}/${file.key}#${file.password}`;
+  const copyLink = useCallback(() => {
+    navigator.clipboard.writeText(link);
+    snackbar({
+      autoHideDuration: ONE_SECOND * 2,
+      message: 'Copied link',
+      open: true,
+    });
+  }, [link, snackbar]);
 
   const openDialog = useCallback(() => setIsDialogOpen(true), []);
   const closeDialog = useCallback(() => setIsDialogOpen(false), []);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(ShareLink): display snackbar message when "Copy link" is pressed

## What is the current behavior?

No feedback when "Copy link" button is pressed

## What is the new behavior?

Snackbar message "Copied link" is displayed when "Copy link" is pressed

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation