### PR TITLE
feat(ShareLink): display snackbar message "Deleted file" on delete

### DIFF
--- a/cypress/e2e/upload/upload.feature
+++ b/cypress/e2e/upload/upload.feature
@@ -20,7 +20,8 @@ Feature: Upload
     When I find buttons by text "Delete"
       And I get last element
       And I click
-    Then I see URL "/"
+    Then I see text "Deleted file"
+      And I see URL "/"
     When I go back
     Then I do not see URL "/"
 

--- a/src/pages/ShareLink/ShareLink.test.tsx
+++ b/src/pages/ShareLink/ShareLink.test.tsx
@@ -179,6 +179,12 @@ describe('with file key and password', () => {
         key: '',
         password: '',
       });
+
+      expect(store.getState().snackbar).toMatchObject({
+        autoHideDuration: 2000,
+        message: 'Deleted file',
+        open: true,
+      });
     });
   });
 
@@ -210,6 +216,12 @@ describe('with file key and password', () => {
         files,
         key: '',
         password: '',
+      });
+
+      expect(store.getState().snackbar).toMatchObject({
+        autoHideDuration: 6000,
+        message: '',
+        open: false,
       });
     });
   });

--- a/src/pages/ShareLink/ShareLink.tsx
+++ b/src/pages/ShareLink/ShareLink.tsx
@@ -40,11 +40,11 @@ export default function ShareLink() {
       message: 'Copied link',
       open: true,
     });
-  }, [link, snackbar]);
+  }, [link]);
 
   const openDialog = useCallback(() => setIsDialogOpen(true), []);
   const closeDialog = useCallback(() => setIsDialogOpen(false), []);
-  const handleDeleteFile = useCallback(async () => {
+  const onDelete = useCallback(async () => {
     let status = 0;
 
     try {
@@ -62,6 +62,11 @@ export default function ShareLink() {
     if ([OK, NOT_FOUND].includes(status)) {
       setIsDialogOpen(false);
       dispatch(actions.resetFile());
+      snackbar({
+        autoHideDuration: ONE_SECOND * 2,
+        message: 'Deleted file',
+        open: true,
+      });
     }
   }, [file.key]);
 
@@ -111,7 +116,7 @@ export default function ShareLink() {
           content="This action cannot be undone."
           id={file.key}
           onClose={closeDialog}
-          onDelete={handleDeleteFile}
+          onDelete={onDelete}
           open={isDialogOpen}
           title="Are you sure you want to delete this file?"
         />


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(ShareLink): display snackbar message "Deleted file" on delete

## What is the current behavior?

No feedback when file is deleted

## What is the new behavior?

Snackbar message "File deleted" when file is deleted

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation